### PR TITLE
Stop internal exception on close of output stream

### DIFF
--- a/source/nanoFramework.System.Net.Http/Http/System.Net._OutputNetworkStreamWrapper.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net._OutputNetworkStreamWrapper.cs
@@ -129,7 +129,7 @@ namespace System.Net
                 m_headersSend();
             }
 
-            m_Stream.Close();
+            if (m_Stream != null) m_Stream.Close();
             m_Stream = null;
             m_Socket = null;
         }


### PR DESCRIPTION
Stream can be closed twice causing an exception
Currently HTTP code traps this exception but there was no need for it in the first place.
It was still displayed on debug console.