### PR TITLE
Add projects for separated client and server only API

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,12 +45,59 @@ variables:
 steps:
 
 # step from template @ nf-tools repo
-# all build, update and publish steps
-- template: azure-pipelines-templates/class-lib-build.yml@templates  
+# build steps only
+- template: azure-pipelines-templates/class-lib-build-only.yml@templates  
+
+# package steps
+- template: azure-pipelines-templates/class-lib-package.yml@templates  
   parameters:
-    sourceFileName: 'nf_networking_sntp.cpp'
-    classLibName: 'nanoFramework.System.Net.Http'
-    skipNativeUpdate: true
+    nugetPackageName: 'nanoFramework.System.Net.Http'
+
+- template: azure-pipelines-templates/class-lib-package.yml@templates  
+  parameters:
+    nugetPackageName: 'nanoFramework.System.Net.Http-client'
+
+- template: azure-pipelines-templates/class-lib-package.yml@templates  
+  parameters:
+    nugetPackageName: 'nanoFramework.System.Net.Http-server'
+
+# create or update GitHub release
+- task: GitHubReleasePublish@1
+  inputs:
+    githubEndpoint: 'nanoframework'
+    githubOwner: 'nanoframework'
+    githubRepositoryName: $(repoName)
+    githubTag: v$(MY_NUGET_VERSION)
+    githubReleaseTitle: '$(nugetPackageName) Library v$(MY_NUGET_VERSION)'
+    githubReleaseNotes: 'Check the [changelog]($(Build.Repository.Uri)/blob/$(Build.SourceBranchName)/CHANGELOG.md).<br><br><h4>Install from nanoFramework MyGet development feed</h4><br>The following NuGet packages are available for download from this release:<br>:package: [.NET](https://www.myget.org/feed/nanoframework-dev/package/nuget/$(nugetPackageName)/$(MY_NUGET_VERSION)) v$(MY_NUGET_VERSION)<br>:package: [.NET (client API only)](https://www.myget.org/feed/nanoframework-dev/package/nuget/nanoFramework.System.Net.Http-client/$(MY_NUGET_VERSION)) v$(MY_NUGET_VERSION).<br>:package: [.NET (server API only)](https://www.myget.org/feed/nanoframework-dev/package/nuget/nanoFramework.System.Net.Http-server/$(MY_NUGET_VERSION)) v$(MY_NUGET_VERSION).'
+    githubTargetCommitsh: $(Build.SourceVersion)
+    githubReleaseDraft: true
+    githubReleasePrerelease: true
+    githubReuseDraftOnly: true
+    githubReuseRelease: true
+    githubEditRelease: true
+    githubReleaseAsset: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+  condition: and( succeeded(), not( startsWith(variables['Build.SourceBranch'], 'refs/pull') ), not( startsWith(variables['Build.SourceBranch'], 'refs/tags/v') ) )
+  displayName: Create/Update GitHub release
+
+# create or update GitHub release ON tags from release or master branches
+- task: GitHubReleasePublish@1
+  inputs:
+    githubEndpoint: 'nanoframework'
+    githubOwner: 'nanoframework'
+    githubRepositoryName: $(repoName)
+    githubTag: v$(MY_NUGET_VERSION)
+    githubReleaseTitle: '$(nugetPackageName) Library v$(MY_NUGET_VERSION)'
+    githubReleaseNotes: 'Check the [changelog]($(Build.Repository.Uri)/blob/$(Build.SourceBranchName)/CHANGELOG.md).<br><br><h4>Install from NuGet</h4><br>The following NuGet packages are available for download from this release:<br>:package: [.NET](https://www.nuget.org/packages/$(nugetPackageName)/$(MY_NUGET_VERSION)) v$(MY_NUGET_VERSION).<br>:package: [.NET (client API only)](https://www.nuget.org/packages/nanoFramework.System.Net.Http-client/$(MY_NUGET_VERSION)) v$(MY_NUGET_VERSION).<br>:package: [.NET (server API only)](https://www.nuget.org/packages/nanoFramework.System.Net.Http-server/$(MY_NUGET_VERSION)) v$(MY_NUGET_VERSION).'
+    githubTargetCommitsh: $(Build.SourceVersion)
+    githubReleaseDraft: false
+    githubReleasePrerelease: false
+    githubReuseDraftOnly: false
+    githubReuseRelease: true
+    githubEditRelease: true
+    githubReleaseAsset: '$(Build.ArtifactStagingDirectory)/*.nupkg'
+  condition: and( succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v') )
+  displayName: Create/Update GitHub release
 
 # step from template @ nf-tools repo
 # report error

--- a/source/nanoFramework.System.Net.Http-client.nuspec
+++ b/source/nanoFramework.System.Net.Http-client.nuspec
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
-    <id>nanoFramework.System.Net.Http</id>
+    <id>nanoFramework.System.Net.Http-client</id>
     <version>$version$</version>
-    <title>nanoFramework.System.Net.Http</title>
+    <title>nanoFramework.System.Net.Http-client</title>
     <authors>nanoFramework project contributors</authors>
     <owners>nanoFramework project contributors</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -14,11 +14,10 @@
     <iconUrl>https://secure.gravatar.com/avatar/97d0e092247f0716db6d4b47b7d1d1ad</iconUrl>
     <copyright>Copyright (c) 2018 The nanoFramework project contributors</copyright>
     <description>
-      This package includes the nanoFramework.System.Net.Http assembly for nanoFramework C# projects.
-      There are also two other packages with just the client API and just the server API.
-      These are meant to be used when there is the need to use smaller assemblies.
+      This package includes the nanoFramework.System.Net.Http assembly (client API only) for nanoFramework C# projects.
+      There is also a package with the server API only and another with the full API.
     </description>
-    <summary>nanoFramework.System.Net.Http assembly for nanoFramework C# projects</summary>
+    <summary>nanoFramework.System.Net.Http assembly (client API only) for nanoFramework C# projects</summary>
     <tags>nanoFramework C# csharp netmf netnf nanoFramework.System.Net.Http</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="[1.1.1]" />
@@ -27,10 +26,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.dll" target="lib\System.Net.Http.dll" />
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.pdb" target="lib\System.Net.Http.pdb" />
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.pdbx" target="lib\System.Net.Http.pdbx" />
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.pe" target="lib\System.Net.Http.pe" />
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.xml" target="lib\System.Net.Http.xml" />
+    <file src="nanoFramework.System.Net.Http-client\bin\Release\System.Net.Http.dll" target="lib\System.Net.Http.dll" />
+    <file src="nanoFramework.System.Net.Http-client\bin\Release\System.Net.Http.pdb" target="lib\System.Net.Http.pdb" />
+    <file src="nanoFramework.System.Net.Http-client\bin\Release\System.Net.Http.pdbx" target="lib\System.Net.Http.pdbx" />
+    <file src="nanoFramework.System.Net.Http-client\bin\Release\System.Net.Http.pe" target="lib\System.Net.Http.pe" />
+    <file src="nanoFramework.System.Net.Http-client\bin\Release\System.Net.Http.xml" target="lib\System.Net.Http.xml" />
   </files>
 </package>

--- a/source/nanoFramework.System.Net.Http-client/System.Net.Http-client.nfproj
+++ b/source/nanoFramework.System.Net.Http-client/System.Net.Http-client.nfproj
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>6c6ee1b2-20f0-4f0e-8085-7ecd1e692567</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>System.Net.Http</RootNamespace>
+    <AssemblyName>System.Net.Http</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <DocumentationFile>bin\$(Configuration)\System.Net.Http.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.Http.Constants.cs">
+      <Link>Http\System.Net.Http.Constants.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.Internal.WebRequestPrefixElement.cs">
+      <Link>Http\System.Net.Internal.WebRequestPrefixElement.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.AuthenticationType.cs">
+      <Link>Http\System.Net.AuthenticationType.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpStatusCode.cs">
+      <Link>Http\System.Net.HttpStatusCode.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpVersion.cs">
+      <Link>Http\System.Net.HttpVersion.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpWebRequest.cs">
+      <Link>Http\System.Net.HttpWebRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpWebResponse.cs">
+      <Link>Http\System.Net.HttpWebResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.Internal.cs">
+      <Link>Http\System.Net.Internal.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.iwebproxy.cs">
+      <Link>Http\System.Net.iwebproxy.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.IWebRequestCreate.cs">
+      <Link>Http\System.Net.IWebRequestCreate.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.NetworkCredential.cs">
+      <Link>Http\System.Net.NetworkCredential.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.ProtocolViolationException.cs">
+      <Link>Http\System.Net.ProtocolViolationException.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebException.cs">
+      <Link>Http\System.Net.WebException.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebHeaders.cs">
+      <Link>Http\System.Net.WebHeaders.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.webproxy.cs">
+      <Link>Http\System.Net.webproxy.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebRequest.cs">
+      <Link>Http\System.Net.WebRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebResponse.cs">
+      <Link>Http\System.Net.WebResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebStatus.cs">
+      <Link>Http\System.Net.WebStatus.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._HeaderInfo.cs">
+      <Link>Http\System.Net._HeaderInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._HeaderInfoTable.cs">
+      <Link>Http\System.Net._HeaderInfoTable.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._HttpDateParse.cs">
+      <Link>Http\System.Net._HttpDateParse.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._InputNetworkStreamWrapper.cs">
+      <Link>Http\System.Net._InputNetworkStreamWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._OutputNetworkStreamWrapper.cs">
+      <Link>Http\System.Net._OutputNetworkStreamWrapper.c</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._ValidationHelper.cs">
+      <Link>Http\System.Net._ValidationHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Uri.cs">
+      <Link>Http\System.Uri.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\key.snk" />
+    <None Include="\nanoFramework.System.Net.Http\packages.config" >
+      <Link>packages.config</Link>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib, Version=1.1.1.7, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.1.1\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.5-preview-008\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net, Version=1.0.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.0.6-preview-011\lib\System.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Http\" />
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+  <Import Project="..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets'))" />
+  </Target>
+</Project>

--- a/source/nanoFramework.System.Net.Http-server.nuspec
+++ b/source/nanoFramework.System.Net.Http-server.nuspec
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
-    <id>nanoFramework.System.Net.Http</id>
+    <id>nanoFramework.System.Net.Http-server</id>
     <version>$version$</version>
-    <title>nanoFramework.System.Net.Http</title>
+    <title>nanoFramework.System.Net.Http-server</title>
     <authors>nanoFramework project contributors</authors>
     <owners>nanoFramework project contributors</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -14,11 +14,10 @@
     <iconUrl>https://secure.gravatar.com/avatar/97d0e092247f0716db6d4b47b7d1d1ad</iconUrl>
     <copyright>Copyright (c) 2018 The nanoFramework project contributors</copyright>
     <description>
-      This package includes the nanoFramework.System.Net.Http assembly for nanoFramework C# projects.
-      There are also two other packages with just the client API and just the server API.
-      These are meant to be used when there is the need to use smaller assemblies.
+      This package includes the nanoFramework.System.Net.Http assembly (server API only) for nanoFramework C# projects.
+      There is also a package with the client API only and another with the full API.
     </description>
-    <summary>nanoFramework.System.Net.Http assembly for nanoFramework C# projects</summary>
+    <summary>nanoFramework.System.Net.Http assembly (server API only) for nanoFramework C# projects</summary>
     <tags>nanoFramework C# csharp netmf netnf nanoFramework.System.Net.Http</tags>
     <dependencies>
       <dependency id="nanoFramework.CoreLibrary" version="[1.1.1]" />
@@ -27,10 +26,10 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.dll" target="lib\System.Net.Http.dll" />
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.pdb" target="lib\System.Net.Http.pdb" />
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.pdbx" target="lib\System.Net.Http.pdbx" />
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.pe" target="lib\System.Net.Http.pe" />
-    <file src="nanoFramework.System.Net.Http\bin\Release\System.Net.Http.xml" target="lib\System.Net.Http.xml" />
+    <file src="nanoFramework.System.Net.Http-server\bin\Release\System.Net.Http.dll" target="lib\System.Net.Http.dll" />
+    <file src="nanoFramework.System.Net.Http-server\bin\Release\System.Net.Http.pdb" target="lib\System.Net.Http.pdb" />
+    <file src="nanoFramework.System.Net.Http-server\bin\Release\System.Net.Http.pdbx" target="lib\System.Net.Http.pdbx" />
+    <file src="nanoFramework.System.Net.Http-server\bin\Release\System.Net.Http.pe" target="lib\System.Net.Http.pe" />
+    <file src="nanoFramework.System.Net.Http-server\bin\Release\System.Net.Http.xml" target="lib\System.Net.Http.xml" />
   </files>
 </package>

--- a/source/nanoFramework.System.Net.Http-server/System.Net.Http-server.nfproj
+++ b/source/nanoFramework.System.Net.Http-server/System.Net.Http-server.nfproj
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <NanoFrameworkProjectSystemPath>$(MSBuildToolsPath)..\..\..\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.Default.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{11A8DD76-328B-46DF-9F39-F559912D0360};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>3b91a15a-40b1-4d57-93f2-eb96af0e7949</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <RootNamespace>System.Net.Http</RootNamespace>
+    <AssemblyName>System.Net.Http</AssemblyName>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <DocumentationFile>bin\$(Configuration)\System.Net.Http.xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
+  <ItemGroup>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.AuthenticationType.cs">
+      <Link>Http\System.Net.AuthenticationType.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.Http.Constants.cs">
+      <Link>Http\System.Net.Http.Constants.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpListener.cs">
+      <Link>Http\System.Net.HttpListener.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpListenerContext.cs">
+      <Link>Http\System.Net.HttpListenerContext.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpListenerRequest.cs">
+      <Link>Http\System.Net.HttpListenerResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpListenerResponse.cs">
+      <Link>
+      </Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpStatusCode.cs">
+      <Link>Http\System.Net.HttpStatusCode.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.HttpVersion.cs">
+      <Link>Http\System.Net.HttpVersion.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.Internal.cs">
+      <Link>Http\System.Net.Internal.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.iwebproxy.cs">
+      <Link>Http\System.Net.iwebproxy.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.NetworkCredential.cs">
+      <Link>Http\System.Net.NetworkCredential.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.ProtocolViolationException.cs">
+      <Link>Http\System.Net.ProtocolViolationException.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebException.cs">
+      <Link>Http\System.Net.WebException.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebHeaders.cs">
+      <Link>Http\System.Net.WebHeaders.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebResponse.cs">
+      <Link>\Http\System.Net.WebResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net.WebStatus.cs">
+      <Link>Http\System.Net.WebStatus.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._HeaderInfo.cs">
+      <Link>Http\System.Net._HeaderInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._HeaderInfoTable.cs">
+      <Link>Http\System.Net._HeaderInfoTable.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._HttpDateParse.cs">
+      <Link>Http\System.Net._HttpDateParse.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._InputNetworkStreamWrapper.cs">
+      <Link>Http\System.Net._InputNetworkStreamWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._OutputNetworkStreamWrapper.cs">
+      <Link>Http\System.Net._OutputNetworkStreamWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Net._ValidationHelper.cs">
+      <Link>Http\System.Net._ValidationHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Http\System.Uri.cs">
+      <Link>Http\System.Uri.cs</Link>
+    </Compile>
+    <Compile Include="..\nanoFramework.System.Net.Http\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\key.snk" />
+    <None Include="\nanoFramework.System.Net.Http\packages.config" >
+      <Link>packages.config</Link>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib, Version=1.1.1.7, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.1.1\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.0.5.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.0.5-preview-008\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net, Version=1.0.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.0.6-preview-011\lib\System.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Http\" />
+  </ItemGroup>
+  <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
+  <ProjectExtensions>
+    <ProjectCapabilities>
+      <ProjectConfigurationsDeclaredAsItems />
+    </ProjectCapabilities>
+  </ProjectExtensions>
+  <Import Project="..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Nerdbank.GitVersioning.3.0.6-beta\build\Nerdbank.GitVersioning.targets'))" />
+  </Target>
+</Project>

--- a/source/nanoFramework.System.Net.Http.sln
+++ b/source/nanoFramework.System.Net.Http.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 15.0.28010.2041
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "System.Net.Http", "nanoFramework.System.Net.Http\System.Net.Http.nfproj", "{C3ABA656-9831-4006-A3B3-EA842A3C508E}"
 EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "System.Net.Http-client", "nanoFramework.System.Net.Http-client\System.Net.Http-client.nfproj", "{6C6EE1B2-20F0-4F0E-8085-7ECD1E692567}"
+EndProject
+Project("{11A8DD76-328B-46DF-9F39-F559912D0360}") = "System.Net.Http-server", "nanoFramework.System.Net.Http-server\System.Net.Http-server.nfproj", "{3B91A15A-40B1-4D57-93F2-EB96AF0E7949}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -16,6 +20,16 @@ Global
 		{C3ABA656-9831-4006-A3B3-EA842A3C508E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3ABA656-9831-4006-A3B3-EA842A3C508E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C3ABA656-9831-4006-A3B3-EA842A3C508E}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{6C6EE1B2-20F0-4F0E-8085-7ECD1E692567}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C6EE1B2-20F0-4F0E-8085-7ECD1E692567}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C6EE1B2-20F0-4F0E-8085-7ECD1E692567}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C6EE1B2-20F0-4F0E-8085-7ECD1E692567}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C6EE1B2-20F0-4F0E-8085-7ECD1E692567}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{3B91A15A-40B1-4D57-93F2-EB96AF0E7949}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B91A15A-40B1-4D57-93F2-EB96AF0E7949}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B91A15A-40B1-4D57-93F2-EB96AF0E7949}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B91A15A-40B1-4D57-93F2-EB96AF0E7949}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B91A15A-40B1-4D57-93F2-EB96AF0E7949}.Release|Any CPU.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/nanoFramework.System.Net.Http/Http/System.Net.Http.Constants.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net.Http.Constants.cs
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+namespace System.Net
+{
+    internal class HttpConstants
+    {
+        /// <summary>
+        /// The time we keep connection idle with HTTP 1.1
+        /// This is one minute.
+        /// </summary>
+        internal const int DefaultKeepAliveMilliseconds = 60000;
+
+        /// <summary>
+        ///  maximum length of the line in reponse line 
+        /// </summary>
+        internal const int maxHTTPLineLength = 4000;
+    }
+}
+
+

--- a/source/nanoFramework.System.Net.Http/Http/System.Net.HttpListener.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net.HttpListener.cs
@@ -43,12 +43,6 @@ namespace System.Net
         private const int MaxCountOfPendingConnections = 10;
 
         /// <summary>
-        /// The time we keep connection idle with HTTP 1.1
-        /// This is one minute.
-        /// </summary>
-        internal const int DefaultKeepAliveMilliseconds = 60000;
-
-        /// <summary>
         /// Server socket for incoming connections.
         /// </summary>
         private Socket m_listener;
@@ -249,7 +243,7 @@ namespace System.Net
             try
             {
                 // This is a blocking call waiting for more data. 
-                outputStream.m_Socket.Poll(DefaultKeepAliveMilliseconds * 1000, SelectMode.SelectRead);
+                outputStream.m_Socket.Poll(HttpConstants.DefaultKeepAliveMilliseconds * 1000, SelectMode.SelectRead);
 
                 if (outputStream.m_Socket.Available > 0)
                 {

--- a/source/nanoFramework.System.Net.Http/Http/System.Net.HttpListenerRequest.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net.HttpListenerRequest.cs
@@ -122,7 +122,7 @@ namespace System.Net
         internal void ParseHTTPRequest()
         {
             // This is the request line.
-            m_RequestString = m_clientStream.Read_HTTP_Line(HttpWebRequest.maxHTTPLineLength).Trim();
+            m_RequestString = m_clientStream.Read_HTTP_Line(HttpConstants.maxHTTPLineLength).Trim();
 
             // Split request line into 3 strings - VERB, URL and HTTP version.
             char[] delimiter = { ' ' };
@@ -155,7 +155,7 @@ namespace System.Net
             // Now it is list of HTTP headers:
             string line;
             int headersLen = m_maxResponseHeadersLen;
-            while ((line = m_clientStream.Read_HTTP_Header(HttpWebRequest.maxHTTPLineLength)).Length > 0)
+            while ((line = m_clientStream.Read_HTTP_Header(HttpConstants.maxHTTPLineLength)).Length > 0)
             {
                 // line.Length is used for the header. Substruct it.
                 headersLen -= line.Length;

--- a/source/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
@@ -89,7 +89,7 @@ namespace System.Net
                         TimeSpan timePassed = streamWrapper.m_lastUsed - curTime;
 
                         // If the socket is old, then close and remove from the list.
-                        if (timePassed.Milliseconds > HttpListener.DefaultKeepAliveMilliseconds)
+                        if (timePassed.Milliseconds > HttpConstants.DefaultKeepAliveMilliseconds)
                         {
                             m_ConnectedStreams.RemoveAt(i);
                             
@@ -101,7 +101,7 @@ namespace System.Net
                     // turn off the timer if there are no active streams
                     if(m_ConnectedStreams.Count > 0)
                     {
-                        m_DropOldConnectionsTimer.Change( HttpListener.DefaultKeepAliveMilliseconds, System.Threading.Timeout.Infinite );
+                        m_DropOldConnectionsTimer.Change( HttpConstants.DefaultKeepAliveMilliseconds, System.Threading.Timeout.Infinite );
                     }
                 }
             }
@@ -158,11 +158,6 @@ namespace System.Net
         ///  Default delay on the Stream.Read and Stream.Write operations
         /// </summary>
         private const int DefaultReadWriteTimeout = 5 * 60 * 1000; // 5 minutes
-
-        /// <summary>
-        ///  maximum length of the line in reponse line 
-        /// </summary>
-        internal const int maxHTTPLineLength = 4000;
 
         /// <summary>
         ///  Delegate that can be called on Continue Response
@@ -1461,7 +1456,7 @@ namespace System.Net
                     // if the current stream list is empty then start the timer that drops unused connections.
                     if (m_ConnectedStreams.Count == 1)
                     {
-                        m_DropOldConnectionsTimer.Change(HttpListener.DefaultKeepAliveMilliseconds, System.Threading.Timeout.Infinite);
+                        m_DropOldConnectionsTimer.Change(HttpConstants.DefaultKeepAliveMilliseconds, System.Threading.Timeout.Infinite);
                     }
                 }
             }
@@ -1541,7 +1536,7 @@ namespace System.Net
 
             ret.m_shouldClose = !defaultKeepAlive;
             // Parse the request line.
-            string line = inStream.Read_HTTP_Line(maxHTTPLineLength).Trim();
+            string line = inStream.Read_HTTP_Line(HttpConstants.maxHTTPLineLength).Trim();
 
             // Cutoff white spaces
             int currentOffset = 0;
@@ -1597,7 +1592,7 @@ namespace System.Net
             ret.m_chunked = false;
             ret.m_contentLength = -1;
 
-            while ((line = inStream.Read_HTTP_Header(maxHTTPLineLength)).Length > 0)
+            while ((line = inStream.Read_HTTP_Header(HttpConstants.maxHTTPLineLength)).Length > 0)
             {
                 // line.Length is used for the header. Substruct it.
                 headersLength -= line.Length;

--- a/source/nanoFramework.System.Net.Http/Http/System.Net.Internal.WebRequestPrefixElement.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net.Internal.WebRequestPrefixElement.cs
@@ -1,0 +1,24 @@
+//
+// Copyright (c) 2018 The nanoFramework project contributors
+// Portions Copyright (c) Microsoft Corporation.  All rights reserved.
+// See LICENSE file in the project root for full license information.
+//
+
+namespace System.Net
+{
+    internal class WebRequestPrefixElement
+    {
+        public string Prefix;
+        public IWebRequestCreate Creator;
+
+        public WebRequestPrefixElement(string P, IWebRequestCreate C)
+        {
+            Prefix = P;
+            Creator = C;
+        }
+
+    } // class PrefixListElement
+
+} // namespace System.Net
+
+

--- a/source/nanoFramework.System.Net.Http/Http/System.Net.Internal.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net.Internal.cs
@@ -6,19 +6,6 @@
 
 namespace System.Net
 {
-    internal class WebRequestPrefixElement
-    {
-        public string Prefix;
-        public IWebRequestCreate Creator;
-
-        public WebRequestPrefixElement(string P, IWebRequestCreate C)
-        {
-            Prefix = P;
-            Creator = C;
-        }
-
-    } // class PrefixListElement
-
     /// <summary>
     /// Used during parsing to capture all the information contained in the http
     /// status line and headers.

--- a/source/nanoFramework.System.Net.Http/System.Net.Http.nfproj
+++ b/source/nanoFramework.System.Net.Http/System.Net.Http.nfproj
@@ -28,6 +28,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="Http\System.Net.Http.Constants.cs" />
     <Compile Include="Http\System.Net.AuthenticationType.cs" />
     <Compile Include="Http\System.Net.HttpListener.cs" />
     <Compile Include="Http\System.Net.HttpListenerContext.cs" />
@@ -38,6 +39,7 @@
     <Compile Include="Http\System.Net.HttpWebRequest.cs" />
     <Compile Include="Http\System.Net.HttpWebResponse.cs" />
     <Compile Include="Http\System.Net.Internal.cs" />
+    <Compile Include="Http\System.Net.Internal.WebRequestPrefixElement.cs" />
     <Compile Include="Http\System.Net.iwebproxy.cs" />
     <Compile Include="Http\System.Net.IWebRequestCreate.cs" />
     <Compile Include="Http\System.Net.NetworkCredential.cs" />


### PR DESCRIPTION
## Description
- Add new projects and nuspecs to publish separated NuGet packages with client only and server only APIs.
- Split and extract some exiting classes/properties for convenience.
- Update Azure Pipelines yaml accordingly.

## Motivation and Context
- Closes nanoFramework/Home#467.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>

