### PR TITLE
Fix static variables not being initialized in derived class HttpWebRequest

### DIFF
--- a/source/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
@@ -112,6 +112,10 @@ namespace System.Net
         /// </summary>
         static HttpWebRequest()
         {
+            // The static constructor of the base class does not get called before the derived static constructor
+            // so you have to make sure the base class gets initialized in any case if you want to use "RegisterPrefix"
+            Initialize();
+
             // Creates instance of HttpRequestCreator. HttpRequestCreator creates HttpWebRequest
             HttpRequestCreator Creator = new HttpRequestCreator();
             // Register prefix. HttpWebRequest handles both http and https

--- a/source/nanoFramework.System.Net.Http/Http/System.Net.WebRequest.cs
+++ b/source/nanoFramework.System.Net.Http/Http/System.Net.WebRequest.cs
@@ -25,10 +25,10 @@ namespace System.Net
         // (ASP .NET is 90 seconds)
 
         // Lock to syncronize update of s_PrefixList
-        private static object g_listLock = new object();
+        private static object g_listLock;
         // List of WebRequestPrefixElement that keeps prefix ( string ) and
         // IWebRequestCreate
-        private static ArrayList s_PrefixList = new ArrayList();
+        private static ArrayList s_PrefixList;
 
         private static IWebProxy s_defaultProxy = null;
 
@@ -38,7 +38,27 @@ namespace System.Net
         /// </summary>
         protected WebRequest()
         {
+        }
 
+        /// <summary>
+        /// Static constructor to initialize the static variables before the class is used
+        /// </summary>
+        static WebRequest()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Initialize has to be called before the class is used.
+        /// Normally should be called by the constructor above.
+        /// </summary>
+        public static void Initialize()
+        {
+            if (g_listLock == null)
+            {
+                g_listLock = new object();
+                s_PrefixList = new ArrayList();
+            }
         }
 
         ~WebRequest()


### PR DESCRIPTION
## Description
Static variables were not initialized properly.

## Solution
Add initialize function that can be called from derived class and from static constructor, as there is no guarantee that the static constructor gets called before the derived class uses base class functions.

Add call to initialize to HttpWebRequest constructor as it uses base class functions afterwards.
