### PR TITLE
It does compile with latest stable version of nuggets

### DIFF
--- a/source/nanoFramework.System.Net.Http-client/System.Net.Http-client.nfproj
+++ b/source/nanoFramework.System.Net.Http-client/System.Net.Http-client.nfproj
@@ -148,21 +148,19 @@
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.7.3\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.4.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.4.2\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.8.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.8.0\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.0.1.5, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Collections.1.0.1\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.0.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.5.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+    <Reference Include="System.Net, Version=1.5.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/source/nanoFramework.System.Net.Http-client/System.Net.Http-client.nfproj
+++ b/source/nanoFramework.System.Net.Http-client/System.Net.Http-client.nfproj
@@ -50,7 +50,7 @@
     <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll">
+    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Net.1.6.0\lib\System.Net.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -157,8 +157,8 @@
       <HintPath>..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.5.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.6.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.6.0\lib\System.Net.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/source/nanoFramework.System.Net.Http-client/packages.config
+++ b/source/nanoFramework.System.Net.Http-client/packages.config
@@ -3,7 +3,7 @@
   <package id="nanoFramework.CoreLibrary" version="1.7.3" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.8.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.0.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.5.0" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.0.0" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.1.91" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/source/nanoFramework.System.Net.Http-client/packages.config
+++ b/source/nanoFramework.System.Net.Http-client/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.7.3" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.4.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.8.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.0.1" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Net" version="1.5.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.0.0" targetFramework="netnanoframework10" />

--- a/source/nanoFramework.System.Net.Http-server/System.Net.Http-server.nfproj
+++ b/source/nanoFramework.System.Net.Http-server/System.Net.Http-server.nfproj
@@ -142,21 +142,24 @@
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.7.3\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.4.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.4.2\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.8.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.8.0\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.0.1.5, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+    <Reference Include="nanoFramework.System.Collections, Version=1.0.1.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Collections.1.0.1\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.0.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.5.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+    <Reference Include="System.Net, Version=1.5.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/source/nanoFramework.System.Net.Http-server/System.Net.Http-server.nfproj
+++ b/source/nanoFramework.System.Net.Http-server/System.Net.Http-server.nfproj
@@ -50,7 +50,7 @@
     <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll">
+    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Net.1.6.0\lib\System.Net.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -156,8 +156,8 @@
       <HintPath>..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.5.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.6.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.6.0\lib\System.Net.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/source/nanoFramework.System.Net.Http-server/packages.config
+++ b/source/nanoFramework.System.Net.Http-server/packages.config
@@ -3,7 +3,7 @@
   <package id="nanoFramework.CoreLibrary" version="1.7.3" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.8.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.0.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.5.0" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.0.0" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.1.91" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/source/nanoFramework.System.Net.Http-server/packages.config
+++ b/source/nanoFramework.System.Net.Http-server/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.7.3" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.4.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.8.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.0.1" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Net" version="1.5.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.0.0" targetFramework="netnanoframework10" />

--- a/source/nanoFramework.System.Net.Http/System.Net.Http.nfproj
+++ b/source/nanoFramework.System.Net.Http/System.Net.Http.nfproj
@@ -96,21 +96,24 @@
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.7.3\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.4.2.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.Runtime.Events.1.4.2\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.8.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.Runtime.Events.1.8.0\lib\nanoFramework.Runtime.Events.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.0.1.5, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+    <Reference Include="nanoFramework.System.Collections, Version=1.0.1.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Collections.1.0.1\lib\nanoFramework.System.Collections.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.0.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.5.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+    <Reference Include="System.Net, Version=1.5.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll</HintPath>
       <Private>True</Private>
+      <SpecificVersion>True</SpecificVersion>
     </Reference>
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/source/nanoFramework.System.Net.Http/System.Net.Http.nfproj
+++ b/source/nanoFramework.System.Net.Http/System.Net.Http.nfproj
@@ -50,7 +50,7 @@
     <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
-    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll">
+    <NFMDP_PE_LoadHints Include="..\packages\nanoFramework.System.Net.1.6.0\lib\System.Net.dll">
       <InProject>false</InProject>
     </NFMDP_PE_LoadHints>
   </ItemGroup>
@@ -110,8 +110,8 @@
       <HintPath>..\packages\nanoFramework.System.Text.1.0.0\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.5.0.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Net.1.5.0\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.6.0.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Net.1.6.0\lib\System.Net.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/source/nanoFramework.System.Net.Http/packages.config
+++ b/source/nanoFramework.System.Net.Http/packages.config
@@ -3,7 +3,7 @@
   <package id="nanoFramework.CoreLibrary" version="1.7.3" targetFramework="netnanoframework10" />
   <package id="nanoFramework.Runtime.Events" version="1.8.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.0.1" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Net" version="1.5.0" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Net" version="1.6.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.0.0" targetFramework="netnanoframework10" />
   <package id="Nerdbank.GitVersioning" version="3.1.91" developmentDependency="true" targetFramework="netnanoframework10" />
 </packages>

--- a/source/nanoFramework.System.Net.Http/packages.config
+++ b/source/nanoFramework.System.Net.Http/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.7.3" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.Runtime.Events" version="1.4.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.Runtime.Events" version="1.8.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Collections" version="1.0.1" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Net" version="1.5.0" targetFramework="netnanoframework10" />
   <package id="nanoFramework.System.Text" version="1.0.0" targetFramework="netnanoframework10" />


### PR DESCRIPTION
## Description
Nothing more except updating nuggets to latest stable version. Somehow pipeline for doing it automatically failed.

## Motivation and Context
We can't deploy things on our device because this very project relates to old version of system.net nuget and trough this to ancient runtime.events version

- Fixes: it does compile and have newest stable version of nugets

Signed-off-by: adaslesniak<adas@aulendin.net>
