### PR TITLE
Fix HttpWebRequest and HttpWebResponse

### DIFF
--- a/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.HttpWebRequest.cs
@@ -1442,7 +1442,7 @@ namespace System.Net
                 bool isHttps = m_originalUrl.Scheme == "https";
 
                 // We have connected socket. Create request stream
-                retStream = new InputNetworkStreamWrapper(new NetworkStream(socket), socket, !isHttps, proxyServer.Host + ":" + proxyServer.Port);
+                retStream = new InputNetworkStreamWrapper(new NetworkStream(socket), socket, true, proxyServer.Host + ":" + proxyServer.Port);
 
                 // For https proxy works differenly from http.
                 if (isHttps)

--- a/nanoFramework.System.Net.Http/Http/System.Net.HttpWebResponse.cs
+++ b/nanoFramework.System.Net.Http/Http/System.Net.HttpWebResponse.cs
@@ -304,13 +304,9 @@ namespace System.Net
                 // If it is not in the list - Add it
                 if (closeConnection)
                 {
-                    // Add new socket and port used to connect to the list of sockets.
-                    // Save connected socket and Destination IP End Point, so it can be used next time.
-                    // But first we need to validate that this socket is already not in the list. We do not want same socket to be twice in the list.
-
                     HttpWebRequest.RemoveStreamFromPool(m_responseStream);
 
-                    // Closing connection socket.
+                    // Closing connection socket
                     m_responseStream.Dispose();
                 }
                 else
@@ -324,6 +320,29 @@ namespace System.Net
 
             base.Dispose(disposing);
         }
+
+        /// <summary>
+        /// Closes the response stream.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Close"/> method closes the response stream and releases the connection to the resource for reuse by other requests.
+        /// You should not access any properties of the <see cref="HttpWebResponse"/> object after the call to the <see cref="Close"/> method.
+        /// You must call either the <see cref="Stream.Close"/> or the <see cref="HttpWebResponse.Close"/> method to close the stream and release the connection for reuse. It is not necessary to call both <see cref="Stream.Close"/> and <see cref="HttpWebResponse.Close"/>, but doing so does not cause an error. Failure to close the stream can cause your application to run out of connections.
+        /// </remarks>
+        public override void Close()
+        {
+            if (m_responseStream != null)
+            {
+                HttpWebRequest.RemoveStreamFromPool(m_responseStream);
+
+                // Closing connection socket
+                m_responseStream.Dispose();
+
+                // Set flag that we already completed work on this stream.
+                m_responseStream = null;
+            }
+        }
+
     } // class HttpWebResponse
 } // namespace System.Net
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.3.1-preview.{height}",
+  "version": "1.3.2-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- HttpWebResponse was missing  the `Close()` method.
- HttpWebRequest was initializing the input network stream wrongly for HTTPS connections.
- Minor fixes in comments.

## Motivation and Context
- Fixes nanoFramework/Home#616.

## How Has This Been Tested?<!-- (if applicable) -->
- HTTP WebRequest sample.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
